### PR TITLE
ci: authenticate release existence check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,8 @@ jobs:
       - name: Check release availability
         if: ${{ steps.release_commit.outputs.should_continue == 'true' }}
         id: release_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG_NAME="${{ steps.release_version.outputs.tag_name }}"
           VERSION="${{ steps.release_version.outputs.version }}"


### PR DESCRIPTION
## Summary

- Pass GH_TOKEN to the release availability check so gh release view can detect an existing GitHub Release.
- Prevent retry runs from trying to recreate v0.2.5 before reaching npm publish.

## Verification

- Parsed .github/workflows/release.yml with Ruby YAML loader.