### PR TITLE
ci: add dedicated examples build workflow

### DIFF
--- a/.github/workflows/examples-ci.yml
+++ b/.github/workflows/examples-ci.yml
@@ -1,0 +1,49 @@
+name: Examples CI
+
+on:
+  workflow_call:
+
+jobs:
+  nextjs-app:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.12.4
+
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build core package
+        working-directory: packages/core
+        run: pnpm run build
+
+      - name: Build Next.js example
+        working-directory: packages/examples/nextjs-app
+        run: pnpm run build
+
+      - name: Check Next.js build output
+        working-directory: packages/examples/nextjs-app
+        run: |
+          test -d .next
+          test -f .next/BUILD_ID

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -10,6 +10,7 @@ jobs:
     outputs:
       core-changed: ${{ steps.changes.outputs.core }}
       docs-changed: ${{ steps.changes.outputs.docs }}
+      examples-changed: ${{ steps.changes.outputs.examples }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -23,12 +24,26 @@ jobs:
           filters: |
             core:
               - 'packages/core/**'
+              - '.github/workflows/core-ci.yml'
+              - '.github/workflows/main-ci.yml'
               - 'package.json'
               - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
             docs:
               - 'docs/**'
+              - '.github/workflows/docs-ci.yml'
+              - '.github/workflows/link-check-config.json'
+              - '.github/workflows/main-ci.yml'
               - 'package.json'
               - 'pnpm-lock.yaml'
+            examples:
+              - 'packages/core/**'
+              - 'packages/examples/**'
+              - '.github/workflows/examples-ci.yml'
+              - '.github/workflows/main-ci.yml'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
 
   core-ci:
     needs: check-changes
@@ -40,44 +55,16 @@ jobs:
     if: needs.check-changes.outputs.docs-changed == 'true'
     uses: ./.github/workflows/docs-ci.yml
 
+  examples-ci:
+    needs: check-changes
+    if: needs.check-changes.outputs.examples-changed == 'true'
+    uses: ./.github/workflows/examples-ci.yml
+
   integration-test:
     runs-on: ubuntu-latest
-    needs: [check-changes, core-ci, docs-ci]
-    if: always() && (needs.core-ci.result == 'success' || needs.core-ci.result == 'skipped') && (needs.docs-ci.result == 'success' || needs.docs-ci.result == 'skipped')
+    needs: [check-changes, core-ci, docs-ci, examples-ci]
+    if: always() && (needs.core-ci.result == 'success' || needs.core-ci.result == 'skipped') && (needs.docs-ci.result == 'success' || needs.docs-ci.result == 'skipped') && (needs.examples-ci.result == 'success' || needs.examples-ci.result == 'skipped')
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.12.4
-
-      - name: Cache dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build all packages
-        run: pnpm run build
-
-      - name: Verify examples work with built package
-        if: needs.check-changes.outputs.core-changed == 'true'
-        working-directory: packages/examples/nextjs-app
-        run: |
-          pnpm install
-          pnpm run build
+      - name: Verify required CI jobs completed
+        run: echo "All required CI jobs completed successfully."


### PR DESCRIPTION
## Summary
- example build を専用の reusable workflow に切り出し
- core / example / workflow / lockfile 変更時に examples CI を実行
- integration-test は core/docs/examples CI の集約 gate に変更

## Verification
- pnpm install --frozen-lockfile
- pnpm --dir packages/core run build
- pnpm --dir packages/examples/nextjs-app run build
- test -d packages/examples/nextjs-app/.next
- test -f packages/examples/nextjs-app/.next/BUILD_ID
- git diff --check